### PR TITLE
[ofono-ril-plugin] Treat no call as a remote hangup.

### DIFF
--- a/src/ril_voicecall.c
+++ b/src/ril_voicecall.c
@@ -301,7 +301,12 @@ static void ril_voicecall_lastcause_cb(GRilIoChannel *io, int status,
 
 		case CALL_FAIL_NORMAL_UNSPECIFIED:
 			call_status = ril_voicecall_status_with_id(vc, id);
-			if (call_status == OFONO_CALL_STATUS_ACTIVE ||
+			/* If call cid doesn't exist anymore, above method returns -1.
+			   This case can happen, when the cause response is received
+			   after the status response that removed the call from the
+			   list. We then assume that the remote is the cause. */
+			if (call_status == -1 ||
+			    call_status == OFONO_CALL_STATUS_ACTIVE ||
 			    call_status == OFONO_CALL_STATUS_HELD ||
 			    call_status == OFONO_CALL_STATUS_DIALING ||
 			    call_status == OFONO_CALL_STATUS_ALERTING) {


### PR DESCRIPTION
On an incoming call, when the caller hangup
before pickup the call on device, the reason
is set as OFONO_DISCONNECT_REASON_ERROR, which
makes the device emitting three tones at full
blow.

This is due to the following exchange in the
modem:
- slot1 > 2 callStateChanged
- slot1 < [00000157] 10 getCurrentCalls
- slot1 > [00000157] 140 getCurrentCallsResponse_1_2
- slot1 < [0000015b] 19 getLastCallFailCause
- slot1 > [0000015b] 18 getLastCallFailCauseResponse

The current calls response contains no call,
so self->calls in binder_voicecall.c is emptied.
Then, the getLastCallFailCauseResponse, gives
RADIO_LAST_CALL_FAIL_NORMAL_UNSPECIFIED as a reason, so the code look for the status of the call. Which has been deleted from the list.

@mlehtima , this is the same patch as the one proposed in mer-hybris/ofono-binder-plugin#29.